### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -206,7 +206,7 @@ jobs:
         run: tar -xzvf native-artifacts.tgz
       - name: Publish to Registry XBuilder Server
         # Uses sha for added security since tags can be updated
-        uses: elgohr/Publish-Docker-Github-Action@b2f63259b466ca5a4be395c392546de447450334
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: projectopenubl/xbuilder-server
           dockerfile: distribution/server-x/src/main/docker/Dockerfile.native

--- a/.github/workflows/release-actions.yml
+++ b/.github/workflows/release-actions.yml
@@ -132,7 +132,7 @@ jobs:
         run: tar -xzvf native-container-artifacts.tgz
       - name: Publish to Registry XML Builder (Release tag)
         # Uses sha for added security since tags can be updated
-        uses: elgohr/Publish-Docker-Github-Action@b2f63259b466ca5a4be395c392546de447450334
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: projectopenubl/xbuilder-server
           dockerfile: distribution/server-x/src/main/docker/Dockerfile.native
@@ -141,7 +141,7 @@ jobs:
           tag_names: true
       - name: Publish to Registry XML Builder (Release latest)
         # Uses sha for added security since tags can be updated
-        uses: elgohr/Publish-Docker-Github-Action@b2f63259b466ca5a4be395c392546de447450334
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: projectopenubl/xbuilder-server
           dockerfile: distribution/server-x/src/main/docker/Dockerfile.native


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore